### PR TITLE
Support service account name in springboot chart

### DIFF
--- a/charts/springboot/templates/deployment.yaml
+++ b/charts/springboot/templates/deployment.yaml
@@ -64,6 +64,12 @@ spec:
       initContainers:
 {{ toYaml .Values.initContainers | indent 8 }}
       {{ end }}
+      {{- if .Values.serviceAccountName }}
+      serviceAccountName: {{ .Values.serviceAccountName | quote }}
+      {{- end }}
+      {{- if .Values.automountServiceAccountToken }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
+      {{- end }}
       containers:
         - name: {{ template "name" . }}
           image: "{{ .Values.global.image.repository }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"

--- a/charts/springboot/templates/deployment.yaml
+++ b/charts/springboot/templates/deployment.yaml
@@ -60,6 +60,9 @@ spec:
       {{- end }}
       securityContext:
         runAsUser: {{ required "podUID must be specified!" .Values.podUID }}
+        {{- if .Values.fsGroup }}
+        fsGroup: {{ .Values.fsGroup }}
+        {{- end }}
       {{ if .Values.initContainers }}
       initContainers:
 {{ toYaml .Values.initContainers | indent 8 }}


### PR DESCRIPTION
```
Support specifying fsGroup in springboot chart
    
Might especially be useful with service account sometimes, e.g. see:
    
https://github.com/aws/amazon-eks-pod-identity-webhook/issues/8#issuecomment-531343852
https://github.com/kubernetes/kubernetes/issues/82573
```
```
Support specifying service account in springboot chart
```