### PR TITLE
Support environment vars in springboot chart cronjobs

### DIFF
--- a/charts/springboot/templates/cronjobs.yaml
+++ b/charts/springboot/templates/cronjobs.yaml
@@ -32,6 +32,35 @@ spec:
               - {{ . | replace "%FULLNAME%" (include "fullname" $) | quote }}
               {{- end }}
             {{- end }}
+            {{- if $definition.env }}
+            env:
+            {{- $secretName := include "secretname" $ -}}
+              {{- range $envname, $envdef := $definition.env }}
+              - name: {{ $envname | quote }}
+                {{- if $envdef.sensitive }}
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ $secretName | quote }}
+                    key: {{ $envdef.key | default $envname | quote }}
+                    {{- if $envdef.optional }}
+                    optional: true
+                    {{- end }}
+                {{- else if $envdef.configMapKeyRef }}
+                valueFrom:
+                  configMapKeyRef:
+{{ toYaml $envdef.configMapKeyRef | indent 20 }}
+                {{- else if $envdef.secretKeyRef }}
+                valueFrom:
+                  secretKeyRef:
+{{ toYaml $envdef.secretKeyRef | indent 20 }}
+                {{- else }}
+                value: {{ required (printf "Value for variable cronJobs.%s.env.%s.value is undefined" $name $envname) $envdef.value | quote }}
+                {{- if $envdef.optional }}
+                optional: true
+                {{- end }}
+                {{- end }}
+              {{- end }}
+            {{ end }}
           restartPolicy: Never
       backoffLimit: {{ $definition.backoffLimit }}
       activeDeadlineSeconds: {{ $definition.activeDeadlineSeconds }}


### PR DESCRIPTION
Implementation has been 'stolen' from the respective part of
springboot/templates/deployment.yaml So env specification is exactly the
same as in deployment