### PR TITLE
fix(springboot): remove whitespace trimming for startupProbe in deployment

### DIFF
--- a/charts/springboot/templates/deployment.yaml
+++ b/charts/springboot/templates/deployment.yaml
@@ -141,7 +141,7 @@ spec:
           {{- end }}
           {{- include "renderOptionalYamlOrTpl" (dict "context" $ "values" .Values "key" "livenessProbe") | nindent 10 -}}
           {{- include "renderOptionalYamlOrTpl" (dict "context" $ "values" .Values "key" "readinessProbe") | nindent 10 -}}
-          {{- include "renderOptionalYamlOrTpl" (dict "context" $ "values" .Values "key" "startupProbe") | nindent 10 -}}
+          {{- include "renderOptionalYamlOrTpl" (dict "context" $ "values" .Values "key" "startupProbe") | nindent 10 }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
       {{- if .Values.image.pullSecret }}


### PR DESCRIPTION
If startupProbe is present, due to white space trimming, it eats up a new line and the end result is invalid as the generated yaml consists of:
startupProbe:...resources:...
Instead of:
startupProbe:...
resources:...